### PR TITLE
Update OTP and Erlang versions matrix in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: ['24.3', '23.3']
-        elixir: ['1.13.4', '1.12.3', '1.11.4']
+        otp: ['25.3', '24.3']
+        elixir: ['1.15.2', '1.14.4', '1.13.4']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Elixir


### PR DESCRIPTION
Due to operating system compatibility issues, CI is failing with older versions of Erlang OTP.
This PR aims to update the OTP and Erlang versions used in CI to newer ones.